### PR TITLE
Fixed .mana.schaos.small styling

### DIFF
--- a/css/mana-cost.css
+++ b/css/mana-cost.css
@@ -87,7 +87,7 @@
 .mana.s100.medium { width: 3.7em; }
 /*.mana.s100.large { width: 10.8em; }*/
 .mana.schaos { background-position: 76.5% 100%; }
-.mana.schaos.small { width: 1.2; }
+.mana.schaos.small { width: 1.2em; }
 .mana.schaos.medium { width: 2.3em; }
 /*.mana.sc.large { width: 4.6em; }*/
 .mana.shw { background-position: 83.5% 100%; }


### PR DESCRIPTION
The width value was missing "em".
The mana symbol is no longer cut off on the left side after the change.